### PR TITLE
Refer to correct location for query params

### DIFF
--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -258,7 +258,7 @@ and where you get it now if you're a route component (`this.props`)
 | `getPath()`     | `location.pathname+location.query` |
 | `getPathname()` | `location.pathname`                |
 | `getParams()`   | `params`                           |
-| `getQuery()`    | `query`                            |
+| `getQuery()`    | `location.query`                            |
 | `getRoutes()`   | `routes`                           |
 | `isActive(to, params, query)` | `history.isActive(pathname, query, onlyActiveOnIndex)` |
 


### PR DESCRIPTION
I was trying to understand how to access query params. After some trial and error, I realized that they were located in `this.props.location.query`. The Upgrade Guide incorrectly placed them at `this.props.query`, so I'm updating it to refer to the correct location.

Fixes #1915
