### PR TITLE
Add info about query params to Introduction

### DIFF
--- a/docs/introduction/README.md
+++ b/docs/introduction/README.md
@@ -221,6 +221,8 @@ const Message = React.createClass({
 })
 ```
 
+You can also access parameters from the query string. If you for instance visit `/foo?bar=baz`, you can access `this.props.location.query.bar` to get the value `"baz"` from your Route component. 
+
 That's the gist of React Router. Application UIs are boxes inside of boxes inside of boxes; now you can keep those boxes in sync with the URL and link to them easily.
 
 The docs about [route configuration](/docs/basics/RouteConfiguration.md) describe more of the router's features in depth.


### PR DESCRIPTION
I found it hard to find information about how to access query parameter values in the docs. Adding a short paragraph about it to the "Introduction" guide could help others avoid having to dig deeper for it.
